### PR TITLE
Handle small screens, skip if no model found

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,4 +1,10 @@
+let hasAttemptedSwitch = false;
+
 function selectProModel() {
+  if (hasAttemptedSwitch) {
+    return;
+  }
+
   const modelButton = document.querySelector(
     '[data-test-id="bard-mode-menu-button"]'
   );
@@ -14,44 +20,76 @@ function selectProModel() {
   }
 
   const currentModelName = currentModelSpan.textContent.trim();
-  const targetModelName = "2.5 Pro (preview)";
+  const targetModelNames = ["2.5 Pro (preview)", "2.5 Pro"];
 
-  if (currentModelName !== targetModelName) {
+  if (targetModelNames.includes(currentModelName)) {
+    hasAttemptedSwitch = true;
     console.log(
-      `[Gemini Pro Setter] Current model is "${currentModelName}". Switching to "${targetModelName}".`
+      `[Gemini Pro Setter] "${currentModelName}" is already selected. Observer disconnected.`
+    );
+    observer.disconnect();
+    return;
+  }
+
+  hasAttemptedSwitch = true;
+  console.log(
+    `[Gemini Pro Setter] Current model: "${currentModelName}". Attempting to switch to a Pro model.`
+  );
+
+  modelButton.click();
+
+  setTimeout(() => {
+    const menuItems = document.querySelectorAll(
+      'div[role="menu"] button.mat-mdc-menu-item, .bard-mode-bottom-sheet button.bard-mode-list-button'
     );
 
-    modelButton.click();
+    let bestOptionToClick = null;
+    let foundModelName = "";
 
-    setTimeout(() => {
-      const menuItems = document.querySelectorAll(
-        'div[role="menu"] button.mat-mdc-menu-item'
-      );
+    for (const targetName of targetModelNames) {
       for (const item of menuItems) {
-        const modelNameSpan = item.querySelector(".mode-title");
-        if (
-          modelNameSpan &&
-          modelNameSpan.textContent.trim() === targetModelName
-        ) {
-          console.log(
-            `[Gemini Pro Setter] Found "${targetModelName}" option. Clicking.`
-          );
-          item.click();
+        const modelNameSpan = item.querySelector(
+          ".mode-title, .title-and-description > .gds-label-l"
+        );
+        if (modelNameSpan && modelNameSpan.textContent.trim() === targetName) {
+          bestOptionToClick = item;
+          foundModelName = targetName;
           break;
         }
       }
-    }, 200);
-  }
+      if (bestOptionToClick) {
+        break;
+      }
+    }
+
+    if (bestOptionToClick) {
+      console.log(
+        `[Gemini Pro Setter] Found "${foundModelName}" option in the menu. Clicking.`
+      );
+      bestOptionToClick.click();
+      observer.disconnect();
+      console.log(
+        "[Gemini Pro Setter] Successfully switched model. Observer disconnected."
+      );
+    } else {
+      console.log(
+        `[Gemini Pro Setter] Could not find any suitable Pro model. No further attempts will be made on this page.`
+      );
+      if (document.querySelector('div[role="menu"]')) {
+        modelButton.click();
+      }
+    }
+  }, 500);
 }
 
-const observer = new MutationObserver((mutations) => {
+const observer = new MutationObserver(() => {
   clearTimeout(observer.debounce);
-  observer.debounce = setTimeout(() => {
-    selectProModel();
-  }, 500);
+  observer.debounce = setTimeout(selectProModel, 500);
 });
 
 observer.observe(document.body, {
   childList: true,
   subtree: true,
 });
+
+selectProModel();


### PR DESCRIPTION
- When 2.5 Pro (preview) or 2.5 Pro is not found, escape the loop.
- Load extension only once per page load.
- Handle case where small screen popup for model selector is on bottom of the screen

## Summary by Sourcery

Improve Pro model selection to run only once per page load, handle both preview and final Pro versions across standard and small-screen UIs, and bail out gracefully if no suitable model is found.

New Features:
- Support selecting Pro models in bottom-sheet UI for small screens by adding corresponding selectors.

Bug Fixes:
- Prevent repeated selection attempts by tracking and disconnecting after a switch or if already on a Pro model.
- Gracefully skip selection when no Pro model option is available.

Enhancements:
- Introduce a one-time flag to ensure the extension initializes only once per page load.
- Simplify observer debounce logic and invoke the selection routine immediately at load.